### PR TITLE
Add optional padding to the image

### DIFF
--- a/IconHelper/Arguments.cs
+++ b/IconHelper/Arguments.cs
@@ -1,5 +1,6 @@
 namespace ktsu.IconHelper;
 
+using System.Collections.ObjectModel;
 using CommandLine;
 
 #pragma warning disable CA1812 // Avoid uninstantiated internal classes - this class is instantiated by the CommandLineParser
@@ -15,4 +16,18 @@ internal sealed class Arguments
 
 	[Option('s', "size", Required = false, HelpText = "The maximum size of the icon. Defaults to 128.")]
 	public int Size { get; set; } = 128;
+
+	[Option('p', "padding", Required = false, HelpText = "The number of pixels per size to pad the output image. Must be < (size / 2). Will not change the output size. Defaults to 0.")]
+	public int Padding { get; set; } = 0;
+
+	internal bool Validate(out Collection<string> errors)
+	{
+		errors = [];
+		if (Padding >= Size / 2)
+		{
+			errors.Add("Padding must be less than half the size of the image.");
+		}
+
+		return errors.Count == 0;
+	}
 }

--- a/IconHelper/IconHelper.cs
+++ b/IconHelper/IconHelper.cs
@@ -102,7 +102,6 @@ internal static class IconHelper
 				var center = new PointF(left + (minWidth / 2f), top + (minHeight / 2f));
 
 				// We intentionally only shrink the image and not grow it
-				bool shrinkImage = newSize > args.Size;
 				int finalSize = Math.Min(newSize, args.Size);
 				int finalContentSize = finalSize - (args.Padding * 2);
 				var paddingColor = Rgba32.ParseHex("00000000");

--- a/IconHelper/IconHelper.cs
+++ b/IconHelper/IconHelper.cs
@@ -17,6 +17,12 @@ internal static class IconHelper
 
 	private static void Run(Arguments args)
 	{
+		if (!args.Validate(out var errors))
+		{
+			Console.WriteLine($"Argument validation failed:\n\t{string.Join("\n\t", errors)}");
+			Environment.Exit(1);
+		}
+
 		var color = ColorTranslator.FromHtml(args.Color);
 		var files = Directory.GetFiles(args.InputPath, "*").ToCollection();
 		foreach (string file in files)
@@ -107,7 +113,13 @@ internal static class IconHelper
 
 				if (newSize > args.Size)
 				{
-					image.Mutate(x => x.Resize(args.Size, args.Size));
+					image.Mutate(x => x.Resize(args.Size - (args.Padding * 2), args.Size - (args.Padding * 2))
+						.Pad(args.Size, args.Size, Rgba32.ParseHex("00000000")));
+				}
+				else
+				{
+					image.Mutate(x => x.Resize(newSize - (args.Padding * 2), newSize - (args.Padding * 2))
+						.Pad(newSize, newSize, Rgba32.ParseHex("00000000")));
 				}
 
 				string outputFilePath = Path.Join(args.OutputPath, Path.GetFileName(file));

--- a/IconHelper/IconHelper.cs
+++ b/IconHelper/IconHelper.cs
@@ -103,8 +103,8 @@ internal static class IconHelper
 
 				// We intentionally only shrink the image and not grow it
 				bool shrinkImage = newSize > args.Size;
-				int finalSize = (newSize > args.Size) ? args.Size : newSize;
-				int sizeWithPadding = finalSize - (args.Padding * 2);
+				int finalSize = Math.Min(newSize, args.Size);
+				int finalContentSize = finalSize - (args.Padding * 2);
 				var paddingColor = Rgba32.ParseHex("00000000");
 
 				image.Mutate(x => x
@@ -116,7 +116,7 @@ internal static class IconHelper
 						Y = top,
 					})
 					.Pad(newSize, newSize, paddingColor)
-					.Resize(sizeWithPadding, sizeWithPadding)
+					.Resize(finalContentSize, finalContentSize)
 					.Pad(finalSize, finalSize, paddingColor));
 
 				string outputFilePath = Path.Join(args.OutputPath, Path.GetFileName(file));

--- a/IconHelper/IconHelper.cs
+++ b/IconHelper/IconHelper.cs
@@ -113,12 +113,14 @@ internal static class IconHelper
 
 				if (newSize > args.Size)
 				{
-					image.Mutate(x => x.Resize(args.Size - (args.Padding * 2), args.Size - (args.Padding * 2))
+					int paddedSize = args.Size - (args.Padding * 2);
+					image.Mutate(x => x.Resize(paddedSize, paddedSize)
 						.Pad(args.Size, args.Size, Rgba32.ParseHex("00000000")));
 				}
 				else
 				{
-					image.Mutate(x => x.Resize(newSize - (args.Padding * 2), newSize - (args.Padding * 2))
+					int paddedSize = newSize - (args.Padding * 2);
+					image.Mutate(x => x.Resize(paddedSize, paddedSize)
 						.Pad(newSize, newSize, Rgba32.ParseHex("00000000")));
 				}
 

--- a/IconHelper/IconHelper.cs
+++ b/IconHelper/IconHelper.cs
@@ -101,6 +101,12 @@ internal static class IconHelper
 				int newSize = Math.Max(minWidth, minHeight);
 				var center = new PointF(left + (minWidth / 2f), top + (minHeight / 2f));
 
+				// We intentionally only shrink the image and not grow it
+				bool shrinkImage = newSize > args.Size;
+				int finalSize = (newSize > args.Size) ? args.Size : newSize;
+				int sizeWithPadding = finalSize - (args.Padding * 2);
+				var paddingColor = Rgba32.ParseHex("00000000");
+
 				image.Mutate(x => x
 					.Crop(new()
 					{
@@ -109,20 +115,9 @@ internal static class IconHelper
 						X = left,
 						Y = top,
 					})
-					.Pad(newSize, newSize, Rgba32.ParseHex("00000000")));
-
-				if (newSize > args.Size)
-				{
-					int paddedSize = args.Size - (args.Padding * 2);
-					image.Mutate(x => x.Resize(paddedSize, paddedSize)
-						.Pad(args.Size, args.Size, Rgba32.ParseHex("00000000")));
-				}
-				else
-				{
-					int paddedSize = newSize - (args.Padding * 2);
-					image.Mutate(x => x.Resize(paddedSize, paddedSize)
-						.Pad(newSize, newSize, Rgba32.ParseHex("00000000")));
-				}
+					.Pad(newSize, newSize, paddingColor)
+					.Resize(sizeWithPadding, sizeWithPadding)
+					.Pad(finalSize, finalSize, paddingColor));
 
 				string outputFilePath = Path.Join(args.OutputPath, Path.GetFileName(file));
 

--- a/IconHelper/Properties/launchSettings.json
+++ b/IconHelper/Properties/launchSettings.json
@@ -1,8 +1,0 @@
-{
-  "profiles": {
-    "IconHelper": {
-      "commandName": "Project",
-      "commandLineArgs": "-i \u0022C:\\\\dev\\\\3k\\\\Launcher_Branch\\\\Launcher\\\\IconSource\u0022 -o \u0022C:\\\\dev\\\\3k\\\\Launcher_Branch\\\\Launcher\\\\Icons\u0022 -p 1"
-    }
-  }
-}

--- a/IconHelper/Properties/launchSettings.json
+++ b/IconHelper/Properties/launchSettings.json
@@ -1,0 +1,8 @@
+{
+  "profiles": {
+    "IconHelper": {
+      "commandName": "Project",
+      "commandLineArgs": "-i \u0022C:\\\\dev\\\\3k\\\\Launcher_Branch\\\\Launcher\\\\IconSource\u0022 -o \u0022C:\\\\dev\\\\3k\\\\Launcher_Branch\\\\Launcher\\\\Icons\u0022 -p 1"
+    }
+  }
+}


### PR DESCRIPTION
- Padding will NOT result in the output image being bigger. Instead the image will be inset by the amount of padding added.
- Added validation to ensure we don't try to add so much padding that the image is not visible and we do potentially invalid image operations